### PR TITLE
Refactor comment handling into tag map.

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,7 +1,7 @@
 package flacvorbis
 
 const (
-	APP_VERSION = "0.1.1"
+	APP_VERSION = "0.1.2"
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -1,7 +1,7 @@
 package flacvorbis
 
 const (
-	APP_VERSION = "0.1.2"
+	APP_VERSION = "0.1.3"
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -1,7 +1,7 @@
 package flacvorbis
 
 const (
-	APP_VERSION = "0.1.0"
+	APP_VERSION = "0.1.1"
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -1,7 +1,7 @@
 package flacvorbis
 
 const (
-	APP_VERSION = "0.1.3"
+	APP_VERSION = "0.1.4"
 )
 
 const (

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"strings"
 )
 
 func encodeUint32(n uint32) []byte {
@@ -24,19 +23,4 @@ func packStr(w io.Writer, s string) {
 	data := []byte(s)
 	w.Write(encodeUint32(uint32(len(data))))
 	w.Write(data)
-}
-
-func packMapValue(m map[string]string, key string, value string, sep string) {
-	if xval, exists := m[key]; exists {
-		m[key] = strings.Join([]string{xval, value}, sep)
-	} else {
-		m[key] = value
-	}
-}
-
-func unpackMapValue(m map[string]string, key string, sep string) []string {
-	if xval, exists := m[key]; exists {
-		return strings.Split(xval, sep)
-	}
-	return []string{}
 }

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"strings"
 )
 
 func encodeUint32(n uint32) []byte {
@@ -23,4 +24,19 @@ func packStr(w io.Writer, s string) {
 	data := []byte(s)
 	w.Write(encodeUint32(uint32(len(data))))
 	w.Write(data)
+}
+
+func packMapValue(m map[string]string, key string, value string, sep string) {
+	if xval, exists := m[key]; exists {
+		m[key] = strings.Join([]string{xval, value}, sep)
+	} else {
+		m[key] = value
+	}
+}
+
+func unpackMapValue(m map[string]string, key string, sep string) []string {
+	if xval, exists := m[key]; exists {
+		return strings.Split(xval, sep)
+	}
+	return []string{}
 }

--- a/vorbis.go
+++ b/vorbis.go
@@ -25,7 +25,7 @@ func New() *MetaDataBlockVorbisComment {
 // empty list if the tag is not present. If there
 // is no tag, error would still be nil
 func (c *MetaDataBlockVorbisComment) Get(key string) ([]string, error) {
-	if value, exists := c.Comments[key]; exists {
+	if value, exists := c.Comments[strings.ToUpper(key)]; exists {
 		return value, nil
 	}
 	return []string{}, nil
@@ -33,27 +33,29 @@ func (c *MetaDataBlockVorbisComment) Get(key string) ([]string, error) {
 
 // Add adds a value to an existing tag, or sets the tag if not present
 func (c *MetaDataBlockVorbisComment) Add(key string, val string) error {
-	for _, char := range key {
+	stdKey := strings.ToUpper(key)
+	for _, char := range stdKey {
 		if char < 0x20 || char > 0x7d || char == '=' {
 			return ErrorInvalidFieldName
 		}
 	}
-	if xval, exists := c.Comments[key]; exists {
-		c.Comments[key] = append(xval, val)
+	if xval, exists := c.Comments[stdKey]; exists {
+		c.Comments[stdKey] = append(xval, val)
 	} else {
-		c.Comments[key] = []string{val}
+		c.Comments[stdKey] = []string{val}
 	}
 	return nil
 }
 
 // Sets sets a new tag or replaces replaces the value of a existing tag
 func (c *MetaDataBlockVorbisComment) Set(key string, val []string) error {
-	for _, char := range key {
+	stdKey := strings.ToUpper(key)
+	for _, char := range stdKey {
 		if char < 0x20 || char > 0x7d || char == '=' {
 			return ErrorInvalidFieldName
 		}
 	}
-	c.Comments[key] = val
+	c.Comments[stdKey] = val
 	return nil
 }
 

--- a/vorbis.go
+++ b/vorbis.go
@@ -21,8 +21,9 @@ func New() *MetaDataBlockVorbisComment {
 	}
 }
 
-// Get get all comments with field name specified by the key parameter
-// If there is no match, error would still be nil
+// Gets the values of a tag if it exists, or an
+// empty list if the tag is not present. If there
+// is no tag, error would still be nil
 func (c *MetaDataBlockVorbisComment) Get(key string) ([]string, error) {
 	if value, exists := c.Comments[key]; exists {
 		return value, nil
@@ -30,7 +31,7 @@ func (c *MetaDataBlockVorbisComment) Get(key string) ([]string, error) {
 	return []string{}, nil
 }
 
-// Add adds a key-val pair to the comments
+// Add adds a value to an existing tag, or sets the tag if not present
 func (c *MetaDataBlockVorbisComment) Add(key string, val string) error {
 	for _, char := range key {
 		if char < 0x20 || char > 0x7d || char == '=' {
@@ -42,6 +43,17 @@ func (c *MetaDataBlockVorbisComment) Add(key string, val string) error {
 	} else {
 		c.Comments[key] = []string{val}
 	}
+	return nil
+}
+
+// Sets sets a new tag or replaces replaces the value of a existing tag
+func (c *MetaDataBlockVorbisComment) Set(key string, val []string) error {
+	for _, char := range key {
+		if char < 0x20 || char > 0x7d || char == '=' {
+			return ErrorInvalidFieldName
+		}
+	}
+	c.Comments[key] = val
 	return nil
 }
 

--- a/vorbis_test.go
+++ b/vorbis_test.go
@@ -96,6 +96,22 @@ func TestVorbisFromExistingFlac(t *testing.T) {
 			t.Error("Unexpected artist name: ", res)
 			t.Fail()
 		}
+
+		if res, err := cmt.Get(FIELD_TITLE); err != nil {
+			t.Error(err)
+			t.Fail()
+		} else if len(res) != 1 || res[0] != "Bee Moved" {
+			t.Error("Unexpected title name: ", res)
+			t.Fail()
+		}
+
+		if res, err := cmt.Get(FIELD_GENRE); err != nil {
+			t.Error(err)
+			t.Fail()
+		} else if len(res) != 0 {
+			t.Error("Unexpected genre: ", res)
+			t.Fail()
+		}
 	}
 	check(cmt)
 	new, err := ParseFromMetaDataBlock(cmt.Marshal())

--- a/vorbis_test.go
+++ b/vorbis_test.go
@@ -3,12 +3,28 @@ package flacvorbis
 import (
 	"archive/zip"
 	"bytes"
+	"io/ioutil"
+	"net/http"
 	"strings"
 	"testing"
 
-	httpclient "github.com/ddliu/go-httpclient"
 	flac "github.com/go-flac/go-flac"
 )
+
+func downloadFile(url string) ([]byte, error) {
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	res, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
 
 func TestNewVorbisComment(t *testing.T) {
 	cmt := New()
@@ -22,12 +38,7 @@ func TestNewVorbisComment(t *testing.T) {
 	}
 }
 func TestVorbisFromExistingFlac(t *testing.T) {
-	zipres, err := httpclient.Begin().Get("http://helpguide.sony.net/high-res/sample1/v1/data/Sample_BeeMoved_96kHz24bit.flac.zip")
-	if err != nil {
-		t.Errorf("Error while downloading test file: %s", err.Error())
-		t.FailNow()
-	}
-	zipdata, err := zipres.ReadAll()
+	zipdata, err := downloadFile("http://helpguide.sony.net/high-res/sample1/v1/data/Sample_BeeMoved_96kHz24bit.flac.zip")
 	if err != nil {
 		t.Errorf("Error while downloading test file: %s", err.Error())
 		t.FailNow()
@@ -65,11 +76,6 @@ func TestVorbisFromExistingFlac(t *testing.T) {
 		}
 	}
 
-	if err := cmt.Add(FIELD_GENRE, "Bee Pop"); err != nil {
-		t.Error(err)
-		t.Fail()
-	}
-
 	check := func(cmt *MetaDataBlockVorbisComment) {
 		if cmt.Vendor != "reference libFLAC 1.2.1 win64 20080709" {
 			t.Errorf("Unexpected vendor string: %s\n", cmt.Vendor)
@@ -90,22 +96,6 @@ func TestVorbisFromExistingFlac(t *testing.T) {
 			t.Error("Unexpected artist name: ", res)
 			t.Fail()
 		}
-
-		if res, err := cmt.Get(FIELD_TITLE); err != nil {
-			t.Error(err)
-			t.Fail()
-		} else if len(res) != 1 || res[0] != "Bee Moved" {
-			t.Error("Unexpected title name: ", res)
-			t.Fail()
-		}
-
-		if res, err := cmt.Get(FIELD_GENRE); err != nil {
-			t.Error(err)
-			t.Fail()
-		} else if len(res) != 1 || res[0] != "Bee Pop" {
-			t.Error("Unexpected title name: ", res)
-			t.Fail()
-		}
 	}
 	check(cmt)
 	new, err := ParseFromMetaDataBlock(cmt.Marshal())
@@ -114,5 +104,4 @@ func TestVorbisFromExistingFlac(t *testing.T) {
 		t.Fail()
 	}
 	check(new)
-
 }


### PR DESCRIPTION
Process Vorbis comment as a map for cleaner handling of tags. Allow for setting (in addition to previous add) handling of tags. Case-insensitive handling of tag names. 